### PR TITLE
Update MySugar.php - fix for cannot add dashlets

### DIFF
--- a/include/MySugar/MySugar.php
+++ b/include/MySugar/MySugar.php
@@ -113,6 +113,11 @@ class MySugar{
 			                             'fileLocation' => $dashletsFiles[$_REQUEST['id']]['file']);
 
 		    // add to beginning of the array
+		    
+		    if(!array_key_exists('current_tab',$_SESSION)){
+			$_SESSION["current_tab"] = '0';
+		    }
+		    
 		    array_unshift($pages[$_REQUEST['activeTab']]['columns'][0]['dashlets'], $guid);
 
 		    $current_user->setPreference('dashlets', $dashlets, 0, $this->type);


### PR DESCRIPTION
Full credit for this patch goes to adesimone from suiteforge.org:
https://suiteforge.org/forum/developer-help/1823-unable-to-add-dashlet-at-home-page-screen

It fixes the cannot add dashlets on a new install issue.

I have applied to my install and it fixes it.